### PR TITLE
Add metadata endpoint and update to API v3 endpoints

### DIFF
--- a/Quandl.php
+++ b/Quandl.php
@@ -19,6 +19,7 @@ class Quandl {
 		"symbol"  => 'https://www.quandl.com/api/v1/datasets/%s.%s?%s',
 		"search"  => 'https://www.quandl.com/api/v1/datasets.%s?%s',
 		"list"    => 'https://www.quandl.com/api/v2/datasets.%s?%s',
+		"meta"    => 'https://www.quandl.com/api/v3/datasets/%s/metadata.%s',
 	];
 
 	public function __construct($api_key=null, $format="object") {
@@ -29,6 +30,15 @@ class Quandl {
 	// getSymbol returns data for a given symbol.
 	public function getSymbol($symbol, $params=null) {
 		$url = $this->getUrl("symbol", 
+			$symbol, $this->getFormat(), 
+			$this->arrangeParams($params));
+
+		return $this->getData($url);
+	}
+
+	// getMeta returns metadata for a given symbol.
+	public function getMeta($symbol, $params=null) {
+		$url = $this->getUrl("meta", 
 			$symbol, $this->getFormat(), 
 			$this->arrangeParams($params));
 

--- a/Quandl.php
+++ b/Quandl.php
@@ -16,9 +16,9 @@ class Quandl {
 	public $error;
 
 	private static $url_templates = [
-		"symbol"  => 'https://www.quandl.com/api/v1/datasets/%s.%s?%s',
-		"search"  => 'https://www.quandl.com/api/v1/datasets.%s?%s',
-		"list"    => 'https://www.quandl.com/api/v2/datasets.%s?%s',
+		"symbol"  => 'https://www.quandl.com/api/v3/datasets/%s.%s?%s',
+		"search"  => 'https://www.quandl.com/api/v3/datasets.%s?%s',
+		"list"    => 'https://www.quandl.com/api/v3/datasets.%s?%s',
 		"meta"    => 'https://www.quandl.com/api/v3/datasets/%s/metadata.%s',
 	];
 

--- a/README.md
+++ b/README.md
@@ -214,3 +214,12 @@ mixed getList( string $source [, int $page, int $per_page] )
 ```
 
 Returns a list of symbols in a given source. Number of results per page is limited to 300 by default.
+
+
+#### `getMeta`
+
+```php
+mixed getMeta( string $source [, array $params] )
+```
+
+Returns a metadata about a symbol.

--- a/tests/QuandlTest.php
+++ b/tests/QuandlTest.php
@@ -94,7 +94,7 @@ class QuandlTest extends PHPUnit_Framework_TestCase {
 		$quandl = new Quandl($this->api_key);
 		$quandl->force_curl = $quandl->no_ssl_verify = $force_curl;
 		$r = $quandl->getList("WIKI", 1, 10);
-		$this->assertEquals(10, count($r->docs),
+		$this->assertEquals(10, count($r->datasets),
 			"TEST getList count");
 	}
 
@@ -110,7 +110,7 @@ class QuandlTest extends PHPUnit_Framework_TestCase {
 		$quandl = new Quandl($this->api_key);
 		$quandl->force_curl = $quandl->no_ssl_verify = $force_curl;
 		$r = $quandl->getSearch("crud oil", 1, 10);
-		$this->assertEquals(10, count($r->docs),
+		$this->assertEquals(10, count($r->datasets),
 			"TEST getSearch count");
 	}
 
@@ -119,12 +119,12 @@ class QuandlTest extends PHPUnit_Framework_TestCase {
 		$quandl->force_curl = $quandl->no_ssl_verify = $force_curl;
 		$quandl->cache_handler = array($this, "cacheHandler");
 		$r = $quandl->getSymbol($this->symbol, $this->dates);
-		$count = count($r->data);
+		$count = count($r->dataset->data);
 		$this->assertFalse($quandl->was_cached, 
 			"TEST was_cache should be false");
 
 		$r = $quandl->getSymbol($this->symbol, $this->dates);
-		$this->assertEquals($count, count($r->data), 
+		$this->assertEquals($count, count($r->dataset->data), 
 			"TEST count before and after cache should match");
 
 		$this->assertTrue($quandl->was_cached, 
@@ -147,7 +147,7 @@ class QuandlTest extends PHPUnit_Framework_TestCase {
 			"TEST $format length");
 		
 		$this->assertEquals(
-			"https://www.quandl.com/api/v1/datasets/{$this->symbol}.{$quandl_format}?trim_start={$this->dates['trim_start']}&trim_end={$this->dates['trim_end']}&auth_token={$this->api_key}",
+			"https://www.quandl.com/api/v3/datasets/{$this->symbol}.{$quandl_format}?trim_start={$this->dates['trim_start']}&trim_end={$this->dates['trim_end']}&auth_token={$this->api_key}",
 			$quandl->last_url,
 			"TEST $format url");
 	}

--- a/tests/QuandlTest.php
+++ b/tests/QuandlTest.php
@@ -57,6 +57,11 @@ class QuandlTest extends PHPUnit_Framework_TestCase {
 		$this->_testGetSearch(true);
 	}
 
+	public function testGetMeta() {
+		$this->_testGetMeta();
+		$this->_testGetMeta(true);
+	}
+
 	public function testCache() {
 		$this->_testCache();
 		$this->cache_file and unlink($this->cache_file);
@@ -91,6 +96,14 @@ class QuandlTest extends PHPUnit_Framework_TestCase {
 		$r = $quandl->getList("WIKI", 1, 10);
 		$this->assertEquals(10, count($r->docs),
 			"TEST getList count");
+	}
+
+	private function _testGetMeta($force_curl=false) {
+		$quandl = new Quandl($this->api_key);
+		$quandl->force_curl = $quandl->no_ssl_verify = $force_curl;
+		$r = $quandl->getMeta("GOOG/NASDAQ_AAPL");
+		$this->assertEquals('NASDAQ_AAPL', $r->dataset->dataset_code, "TEST getMeta dataset_code");
+		$this->assertEquals('GOOG', $r->dataset->database_code, "TEST getMeta database_code");
 	}
 
 	private function _testGetSearch($force_curl=false) {

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,3 +20,11 @@ To test a specific method:
 
   $ phpunit --stop-on-failure --filter PartialMethodName .
 
+
+## Travis
+
+If many tests are run through Travis CI, they will eventually fail due to 
+Quandl key-less API quota. You can define the `QUANDL_KEY` environmnt 
+variable in the travis repo settings.
+
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,3 +16,7 @@ In this case, you can simply set your own key in an environment variable:
     $ export QUANDL_KEY=your_key_here
     $ phpunit --stop-on-failure .
 
+To test a specific method:
+
+  $ phpunit --stop-on-failure --filter PartialMethodName .
+


### PR DESCRIPTION
> **NOTE:**  
> Since Quandl has done changes to their API, and since this PR uses the new Quandl API - it may break for users who used the previous version. In previous versions of the API, some responses had a `docs` property, which is now called `datasets`, and other responses had the `data` property, which is not available as `dataset->data`

This PR:

- adds the `getMeta()` method which maps to Quandl's metadata endpoint (https://www.quandl.com/api/v3/datasets/%s/metadata.%s)
- updates all the API endpoints to use v3.

Reference: [Quandl API introduction page][1]

[1]: https://www.quandl.com/blog/getting-started-with-the-quandl-api