### PR TITLE
Add getDatabases and a generic get

### DIFF
--- a/Quandl.php
+++ b/Quandl.php
@@ -20,7 +20,10 @@ class Quandl {
 		"search"  => 'https://www.quandl.com/api/v3/datasets.%s?%s',
 		"list"    => 'https://www.quandl.com/api/v3/datasets.%s?%s',
 		"meta"    => 'https://www.quandl.com/api/v3/datasets/%s/metadata.%s',
+		"dbs"     => 'https://www.quandl.com/api/v3/databases.%s?%s',
 	];
+
+	// --- API Methods
 
 	public function __construct($api_key=null, $format="object") {
 		$this->api_key = $api_key;
@@ -29,17 +32,26 @@ class Quandl {
 
 	// getSymbol returns data for a given symbol.
 	public function getSymbol($symbol, $params=null) {
-		$url = $this->getUrl("symbol", 
-			$symbol, $this->getFormat(), 
+		$url = $this->getUrl("symbol", $symbol, $this->getFormat(), 
 			$this->arrangeParams($params));
 
 		return $this->getData($url);
 	}
 
 	// getMeta returns metadata for a given symbol.
-	public function getMeta($symbol, $params=null) {
-		$url = $this->getUrl("meta", 
-			$symbol, $this->getFormat(), 
+	public function getMeta($symbol) {
+		$url = $this->getUrl("meta", $symbol, $this->getFormat());
+		return $this->getData($url);
+	}
+
+	// getDatabases returns the list of databases. Quandl limits it to 
+	// 100 per page at most.
+	public function getDatabases($page=1, $per_page=100) {
+		$params = [
+			"per_page"    => $per_page, 
+			"page"        => $page, 
+		];
+		$url = $this->getUrl("dbs", $this->getFormat(), 
 			$this->arrangeParams($params));
 
 		return $this->getData($url);
@@ -54,8 +66,7 @@ class Quandl {
 			"page"     => $page, 
 			"query"    => $query,
 		];
-		$url = $this->getUrl("search", 
-			$this->getFormat(true), 
+		$url = $this->getUrl("search", $this->getFormat(true), 
 			$this->arrangeParams($params));
 
 		return $this->getData($url);
@@ -69,12 +80,13 @@ class Quandl {
 			"per_page"    => $per_page, 
 			"page"        => $page, 
 		];
-		$url = $this->getUrl("list", 
-			$this->getFormat(), 
+		$url = $this->getUrl("list", $this->getFormat(), 
 			$this->arrangeParams($params));
 
 		return $this->getData($url);
 	}
+
+	// --- Private Methods
 
 	// getFormat returns one of the three formats supported by Quandl.
 	// It is here for two reasons: 

--- a/Quandl.php
+++ b/Quandl.php
@@ -16,6 +16,7 @@ class Quandl {
 	public $error;
 
 	private static $url_templates = [
+		"direct"  => 'https://www.quandl.com/api/v3/%s.%s?%s',
 		"symbol"  => 'https://www.quandl.com/api/v3/datasets/%s.%s?%s',
 		"search"  => 'https://www.quandl.com/api/v3/datasets.%s?%s',
 		"list"    => 'https://www.quandl.com/api/v3/datasets.%s?%s',
@@ -28,6 +29,15 @@ class Quandl {
 	public function __construct($api_key=null, $format="object") {
 		$this->api_key = $api_key;
 		$this->format = $format;
+	}
+
+	// get provides access to any Quandl API endpoint. There is no need
+	// to include the format.
+	public function get($path, $params=null) {
+		$url = $this->getUrl("direct", $path, $this->getFormat(), 
+			$this->arrangeParams($params));
+
+		return $this->getData($url);
 	}
 
 	// getSymbol returns data for a given symbol.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,15 @@ PHP Quandl
 [![Build Status](https://img.shields.io/travis/DannyBen/php-quandl.svg?maxAge=2592000&style=flat-square)](https://travis-ci.org/DannyBen/php-quandl)
 [![Code Climate](https://img.shields.io/codeclimate/github/DannyBen/php-quandl.svg?maxAge=2592000&style=flat-square)](https://codeclimate.com/github/DannyBen/php-quandl)
 
-This library provides easy access to the 
-[Quandl API](https://www.quandl.com/help/api) 
-using PHP.
+---
 
+This library provides easy access to the [Quandl API][1] using PHP.
+
+It provides several convenience methods to common Quandl API endpoints, as
+well as a generic method to access any of Quandl's endpoints directly.
+
+
+---
 
 Geting Started
 --------------
@@ -64,6 +69,13 @@ supported symbols in a data source:
 $quandl = new Quandl($api_key);
 $data = $quandl->getSearch("crude oil");
 $data = $quandl->getList("WIKI", 1, 10);
+```
+
+To access any Quandl API endpoint directly, use the `get` method
+
+```php
+$quandl = new Quandl($api_key);
+$data = $quandl->get("databases/WIKI");
 ```
 
 More examples can be found in the [examples.php](https://github.com/DannyBen/php-quandl/blob/master/examples.php) file 
@@ -177,6 +189,23 @@ response came from the cache.
 
 ### Methods
 
+#### `get`
+
+```php
+mixed get( string $path [, array $params ] )
+```
+
+Returns an object containing the response from any of Quandl's API
+endpoints. The format of the result depends on the value of 
+`$quandl->format`.
+
+The optional parameters array is an associative `key => value`
+array with any of the parameters supported by Quandl.
+
+You do not need to pass `auth_token` in the array, it will be 
+automatically appended.
+
+
 #### `getSymbol`
 
 ```php
@@ -234,3 +263,6 @@ mixed getDatabases( [int $page, int $per_page] )
 
 Returns a list of available databases. Number of results per page is 
 limited to 100 by default.
+
+
+[1]: https://www.quandl.com/help/api

--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ Holds the last API URL as requested from Quandl, for debugging.
 print $quandl->error;
 ```
 
-In case there was an error getting the data from Quandl, the request response
-will be `false` and this property will contain the error message.
+In case there was an error getting the data from Quandl, the request 
+response will be `false` and this property will contain the error message.
 
 #### `$was_cached`
 
@@ -213,13 +213,24 @@ string instead.
 mixed getList( string $source [, int $page, int $per_page] )
 ```
 
-Returns a list of symbols in a given source. Number of results per page is limited to 300 by default.
+Returns a list of symbols in a given source. Number of results per page is 
+limited to 300 by default.
 
 
 #### `getMeta`
 
 ```php
-mixed getMeta( string $source [, array $params] )
+mixed getMeta( string $source )
 ```
 
-Returns a metadata about a symbol.
+Returns metadata about a symbol.
+
+
+#### `getDatabases`
+
+```php
+mixed getDatabases( [int $page, int $per_page] )
+```
+
+Returns a list of available databases. Number of results per page is 
+limited to 100 by default.

--- a/examples.php
+++ b/examples.php
@@ -8,7 +8,7 @@
 	$symbol  = "GOOG/NASDAQ_AAPL";
 
 	// Modify this call to any `exampleN` to check different samples
-	$data = example1($api_key, $symbol);
+	$data = example10($api_key, $symbol);
 	print_r($data);
 
 	// Example 1: Hello Quandl
@@ -77,8 +77,14 @@
 		return $quandl->getDatabases();
 	}
 
-	// Example 10: Error Handling
-	function example10($api_key, $symbol) {
+	// Example 10: Direct Call (access any Quandl endpoint)
+	function example10($api_key, $symbol=null) {
+		$quandl = new Quandl($api_key);
+		return $quandl->get('databases/WIKI');
+	}
+
+	// Example 11: Error Handling
+	function example11($api_key, $symbol) {
 		$quandl = new Quandl($api_key, "csv");
 		$result = $quandl->getSymbol("DEBUG/INVALID");
 		if($quandl->error and !$result)

--- a/examples.php
+++ b/examples.php
@@ -4,7 +4,7 @@
 	//--------------------------------------------------------------
 	require_once "Quandl.php";
 
-	$api_key = "YOUR_KEY_HERE";
+	$api_key = $_SERVER['QUANDL_KEY'] ?: "YOUR_KEY_HERE";
 	$symbol  = "GOOG/NASDAQ_AAPL";
 
 	// Modify this call to any `exampleN` to check different samples
@@ -71,8 +71,14 @@
 		return $quandl->getMeta($symbol);
 	}
 
-	// Example 9: Error Handling
-	function example9($api_key, $symbol) {
+	// Example 9: List of Databases
+	function example9($api_key, $symbol=null) {
+		$quandl = new Quandl($api_key);
+		return $quandl->getDatabases();
+	}
+
+	// Example 10: Error Handling
+	function example10($api_key, $symbol) {
 		$quandl = new Quandl($api_key, "csv");
 		$result = $quandl->getSymbol("DEBUG/INVALID");
 		if($quandl->error and !$result)

--- a/tests/QuandlTest.php
+++ b/tests/QuandlTest.php
@@ -62,6 +62,10 @@ class QuandlTest extends PHPUnit_Framework_TestCase {
 		$this->_testGetMeta(true);
 	}
 
+	public function testGetDatabases() {
+		$this->_testGetDatabases();
+	}
+
 	public function testCache() {
 		$this->_testCache();
 		$this->cache_file and unlink($this->cache_file);
@@ -104,6 +108,13 @@ class QuandlTest extends PHPUnit_Framework_TestCase {
 		$r = $quandl->getMeta("GOOG/NASDAQ_AAPL");
 		$this->assertEquals('NASDAQ_AAPL', $r->dataset->dataset_code, "TEST getMeta dataset_code");
 		$this->assertEquals('GOOG', $r->dataset->database_code, "TEST getMeta database_code");
+	}
+
+	private function _testGetDatabases() {
+		$quandl = new Quandl($this->api_key);
+		$r = $quandl->getDatabases(1, 5);
+		$this->assertEquals(5, count($r->databases), "TEST getDatabases count");
+		$this->assertTrue(array_key_exists('database_code', $r->databases[0]), "TEST getDatabases keys");
 	}
 
 	private function _testGetSearch($force_curl=false) {

--- a/tests/QuandlTest.php
+++ b/tests/QuandlTest.php
@@ -22,55 +22,83 @@ class QuandlTest extends PHPUnit_Framework_TestCase {
 		$this->cache_file and unlink($this->cache_file);
 	}
 
+	public function testGet() {
+		$quandl = new Quandl($this->api_key);
+		$r = $quandl->get("datasets/GOOG/NASDAQ_AAPL", ['rows' => 5]);
+
+		$this->assertEquals('GOOG', $r->dataset->database_code, "TEST get database_code");
+		$this->assertEquals(5, count($r->dataset->data), "TEST get data count");
+	}
+
 	public function testCsv() {
 		$this->_testGetSymbol("csv", 2800);
-		$this->_testGetSymbol("csv", 2800, true);
 	}
 
 	public function testXml() {
 		$this->_testGetSymbol("xml", 14000);
-		$this->_testGetSymbol("xml", 14000, true);
 	}
 
 	public function testJson() {
 		$this->_testGetSymbol("json", 4200);
-		$this->_testGetSymbol("json", 4200, true);
 	}
 
 	public function testObject() {
 		$this->_testGetSymbol("object", 7400);
-		$this->_testGetSymbol("object", 7400, true);
+	}
+
+	public function testCurl() {
+		$this->_testGetSymbol("csv", 2800, true);
 	}
 
 	public function testInvalidUrl() {
-		$this->_testInvalidUrl();
-		$this->_testInvalidUrl(true);
+		$quandl = new Quandl($this->api_key, "json");
+		$r = $quandl->getSymbol("INVALID/SYMBOL", $this->dates);
+		$this->assertEquals($quandl->error, "Invalid URL", "TEST invalidUrl response");
 	}
 
 	public function testGetList() {
-		$this->_testGetList();
-		$this->_testGetList(true);
+		$quandl = new Quandl($this->api_key);
+		$r = $quandl->getList("WIKI", 1, 10);
+		$this->assertEquals(10, count($r->datasets), "TEST getList count");
 	}
 
 	public function testGetSearch() {
-		$this->_testGetSearch();
-		$this->_testGetSearch(true);
+		$quandl = new Quandl($this->api_key);
+		$r = $quandl->getSearch("crud oil", 1, 10);
+		$this->assertEquals(10, count($r->datasets), "TEST getSearch count");
 	}
 
 	public function testGetMeta() {
-		$this->_testGetMeta();
-		$this->_testGetMeta(true);
+		$quandl = new Quandl($this->api_key);
+		$r = $quandl->getMeta("GOOG/NASDAQ_AAPL");
+		$this->assertEquals('NASDAQ_AAPL', $r->dataset->dataset_code, "TEST getMeta dataset_code");
+		$this->assertEquals('GOOG', $r->dataset->database_code, "TEST getMeta database_code");
 	}
 
 	public function testGetDatabases() {
-		$this->_testGetDatabases();
+		$quandl = new Quandl($this->api_key);
+		$r = $quandl->getDatabases(1, 5);
+		$this->assertEquals(5, count($r->databases), "TEST getDatabases count");
+		$this->assertTrue(array_key_exists('database_code', $r->databases[0]), "TEST getDatabases keys");
 	}
 
 	public function testCache() {
-		$this->_testCache();
-		$this->cache_file and unlink($this->cache_file);
-		$this->_testCache(true);
+		$quandl = new Quandl($this->api_key);
+		$quandl->cache_handler = array($this, "cacheHandler");
+		$r = $quandl->getSymbol($this->symbol, $this->dates);
+		$count = count($r->dataset->data);
+		$this->assertFalse($quandl->was_cached, 
+			"TEST was_cache should be false");
+
+		$r = $quandl->getSymbol($this->symbol, $this->dates);
+		$this->assertEquals($count, count($r->dataset->data), 
+			"TEST count before and after cache should match");
+
+		$this->assertTrue($quandl->was_cached, 
+			"TEST was_cache should be true");
 	}
+
+	// ---
 
 	public function cacheHandler($action, $url, $data=null) {
 		$cache_key = md5("quandl:$url");
@@ -84,62 +112,6 @@ class QuandlTest extends PHPUnit_Framework_TestCase {
 		$this->cache_file = $cache_file;
 		
 		return false;
-	}
-
-	private function _testInvalidUrl($force_curl=false) {
-		$quandl = new Quandl($this->api_key, "json");
-		$quandl->force_curl = $quandl->no_ssl_verify = $force_curl;
-		$r = $quandl->getSymbol("INVALID/SYMBOL", $this->dates);
-		$this->assertEquals($quandl->error, "Invalid URL", 
-			"TEST invalidUrl response");
-	}
-
-	private function _testGetList($force_curl=false) {
-		$quandl = new Quandl($this->api_key);
-		$quandl->force_curl = $quandl->no_ssl_verify = $force_curl;
-		$r = $quandl->getList("WIKI", 1, 10);
-		$this->assertEquals(10, count($r->datasets),
-			"TEST getList count");
-	}
-
-	private function _testGetMeta($force_curl=false) {
-		$quandl = new Quandl($this->api_key);
-		$quandl->force_curl = $quandl->no_ssl_verify = $force_curl;
-		$r = $quandl->getMeta("GOOG/NASDAQ_AAPL");
-		$this->assertEquals('NASDAQ_AAPL', $r->dataset->dataset_code, "TEST getMeta dataset_code");
-		$this->assertEquals('GOOG', $r->dataset->database_code, "TEST getMeta database_code");
-	}
-
-	private function _testGetDatabases() {
-		$quandl = new Quandl($this->api_key);
-		$r = $quandl->getDatabases(1, 5);
-		$this->assertEquals(5, count($r->databases), "TEST getDatabases count");
-		$this->assertTrue(array_key_exists('database_code', $r->databases[0]), "TEST getDatabases keys");
-	}
-
-	private function _testGetSearch($force_curl=false) {
-		$quandl = new Quandl($this->api_key);
-		$quandl->force_curl = $quandl->no_ssl_verify = $force_curl;
-		$r = $quandl->getSearch("crud oil", 1, 10);
-		$this->assertEquals(10, count($r->datasets),
-			"TEST getSearch count");
-	}
-
-	private function _testCache($force_curl=false) {
-		$quandl = new Quandl($this->api_key);
-		$quandl->force_curl = $quandl->no_ssl_verify = $force_curl;
-		$quandl->cache_handler = array($this, "cacheHandler");
-		$r = $quandl->getSymbol($this->symbol, $this->dates);
-		$count = count($r->dataset->data);
-		$this->assertFalse($quandl->was_cached, 
-			"TEST was_cache should be false");
-
-		$r = $quandl->getSymbol($this->symbol, $this->dates);
-		$this->assertEquals($count, count($r->dataset->data), 
-			"TEST count before and after cache should match");
-
-		$this->assertTrue($quandl->was_cached, 
-			"TEST was_cache should be true");
 	}
 
 	private function _testGetSymbol($format, $length, $force_curl=false) {
@@ -162,5 +134,6 @@ class QuandlTest extends PHPUnit_Framework_TestCase {
 			$quandl->last_url,
 			"TEST $format url");
 	}
+
 }
 ?>


### PR DESCRIPTION
This PR:

- adds a `getDatabases` method to get a list of databases
- adds a generic `get` method, to access any Quandl endpoint
- improves tests by testing curl only once, instead of for every request type