### PR TITLE
Add support for downloading entire databases (premium)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dev.php
 /vendor
 composer.lock
+tmp.zip

--- a/Quandl.php
+++ b/Quandl.php
@@ -246,8 +246,14 @@ class Quandl {
 	// simpleDownloadFile downloads a file with fopen and saves the content to 
 	// disk.
 	private function simpleDownloadFile($url, $path) {
-		$bytes_written = file_put_contents($path, fopen($url, 'r'));
-		$success = $bytes_written !== false;
+		if ($this->timeout) {
+			$context = stream_context_create( ['http' => ['timeout' => $this->timeout]] );
+			$success = @file_put_contents($path, fopen($url, 'r', false, $context));
+		}
+		else {
+			$success = @file_put_contents($path, fopen($url, 'r'));
+		}
+
 		$success or $this->error = ($this->timeout ? "Invalid URL or timed out" : "Invalid URL");
 		return $success;
 	}

--- a/Quandl.php
+++ b/Quandl.php
@@ -22,6 +22,7 @@ class Quandl {
 		"list"    => 'https://www.quandl.com/api/v3/datasets.%s?%s',
 		"meta"    => 'https://www.quandl.com/api/v3/datasets/%s/metadata.%s',
 		"dbs"     => 'https://www.quandl.com/api/v3/databases.%s?%s',
+		"bulk"    => 'https://www.quandl.com/api/v3/databases/%s/data?%s',
 	];
 
 	// --- API Methods
@@ -42,10 +43,16 @@ class Quandl {
 
 	// getSymbol returns data for a given symbol.
 	public function getSymbol($symbol, $params=null) {
-		$url = $this->getUrl("symbol", $symbol, $this->getFormat(), 
-			$this->arrangeParams($params));
-
+		$url = $this->getUrl("symbol", $symbol, $this->getFormat(), $this->arrangeParams($params));
 		return $this->getData($url);
+	}
+
+	// getBulk downloads an entire database to a ZIP file.
+	public function getBulk($database, $filename, $complete=false) {
+		$params = [];
+		$params['download_type'] = $complete ? 'complete' : 'partial';
+		$url = $this->getUrl("bulk", $database, $this->arrangeParams($params));
+		return $this->downloadToFile($url, $filename);
 	}
 
 	// getMeta returns metadata for a given symbol.
@@ -185,18 +192,42 @@ class Quandl {
 	// You can disable SSL verification for curl by setting 
 	// $no_ssl_verify to true (solves "SSL certificate problem")
 	private function download($url) {
-		if (ini_get('allow_url_fopen') and !$this->force_curl) {
-			return $this->simpleDownload($url);
-		}
+		$mode = $this->downloadMode();
+		
+		if ($mode == 'simple') return $this->simpleDownload($url);
+		if ($mode == 'curl')   return $this->curlDownload($url);
 
-		if (function_exists('curl_version')) {
-			return $this->curlDownload($url);
-		}
-
-		$this->error = "Enable allow_url_fopen or curl";
+		$this->error = "Cannot download. Please enable allow_url_fopen or curl.";
 		return false;
 	}
 
+	// downloadToFile fetches $url with file_get_contents or curl fallback
+	// You can force curl download by setting $force_curl to true.
+	// You can disable SSL verification for curl by setting 
+	// $no_ssl_verify to true (solves "SSL certificate problem")
+	private function downloadToFile($url, $path) {
+		$mode = $this->downloadMode();
+		
+		if ($mode == 'simple') return $this->simpleDownloadFile($url, $path);
+		if ($mode == 'curl')   return $this->curlDownloadFile($url, $path);
+
+		$this->error = "Cannot download. Please enable allow_url_fopen or curl.";
+		return false;
+	}
+
+	// downloadMode determines if we can download with 
+	// file_get_contents/fopen or curl.
+	private function downloadMode() {
+		if (ini_get('allow_url_fopen') and !$this->force_curl)
+			return 'simple';
+
+		if (function_exists('curl_version'))
+			return 'curl';
+
+		return 'unknown';
+	}
+
+	// simpleDownload gets a URL using file_get_contents and returns its content
 	private function simpleDownload($url) {
 		// Set timeout, doesnt seem to work with ini_set
 		// $this->timeout and ini_set('default_socket_timeout', $this->timeout);
@@ -212,26 +243,67 @@ class Quandl {
 		return $data;
 	}
 
+	// simpleDownloadFile downloads a file with fopen and saves the content to 
+	// disk.
+	private function simpleDownloadFile($url, $path) {
+		$bytes_written = file_put_contents($path, fopen($url, 'r'));
+		$success = $bytes_written !== false;
+		$success or $this->error = ($this->timeout ? "Invalid URL or timed out" : "Invalid URL");
+		return $success;
+	}
+
+	// curlDownload is the curl equivalent of simpleDownload. 
 	private function curlDownload($url) {
+		$options = [
+			CURLOPT_URL => $url,
+			CURLOPT_RETURNTRANSFER => true
+		];
+
+		return $this->curlExecute($options);
+	}
+
+	// curlDownloadFile is the curl equivalent of simpleDownloadFile.
+	private function curlDownloadFile($url, $path) {
+		$fp = fopen($path, 'w+');
+
+		$options = [
+			CURLOPT_URL => $url,
+			CURLOPT_FILE => $fp,
+			CURLOPT_FOLLOWLOCATION => true
+		];
+
+		$response = $this->curlExecute($options);
+		
+		fclose($fp);
+
+		return $response;
+	}
+
+	// curlExecute handles generic curl execution, for DRYing the two other
+	// functions that rely on curl.
+	private function curlExecute($options) {
 		$curl = curl_init();
 
-		curl_setopt($curl, CURLOPT_URL, $url);
-		curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+		curl_setopt_array($curl, $options);
+
 		$this->timeout       and curl_setopt($curl, CURLOPT_TIMEOUT, $this->timeout);
 		$this->no_ssl_verify and curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);
 
-		$data  = curl_exec($curl);
+		$response = curl_exec($curl);
 		$error = curl_error($curl);
 		$http_code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+		
 		curl_close($curl);
+
 		if ($http_code == "404") {
-			$data = false;
+			$response = false;
 			$this->error = "Invalid URL";
 		}
 		else if ($error) {
-			$data = false;
+			$response = false;
 			$this->error = $error;
 		}
-		return $data;
+
+		return $response;
 	}
 }

--- a/README.md
+++ b/README.md
@@ -216,8 +216,8 @@ automatically appended.
 mixed getSymbol( string $symbol [, array $params ] )
 
 // Examples
-$data = $quandl->getSymbol( 'WIKI/AAPL' )
-$data = $quandl->getSymbol( 'WIKI/AAPL', ['rows' => 5] )
+$data = $quandl->getSymbol( 'WIKI/AAPL' );
+$data = $quandl->getSymbol( 'WIKI/AAPL', ['rows' => 5] );
 ```
 
 Returns an object containing data for a given symbol. The format
@@ -236,8 +236,8 @@ automatically appended.
 mixed getSearch( string $query [, int $page, int $per_page] )
 
 // Examples
-$data = $quandl->getSearch( "gold" )
-$data = $quandl->getSearch( "gold", 1, 10 )
+$data = $quandl->getSearch( "gold" );
+$data = $quandl->getSearch( "gold", 1, 10 );
 ```
 
 Returns a search result object. Number of results per page is 
@@ -254,8 +254,8 @@ string instead.
 mixed getList( string $source [, int $page, int $per_page] )
 
 // Examples
-$data = $quandl->getList( 'WIKI' )
-$data = $quandl->getList( 'WIKI', 1, 10 )
+$data = $quandl->getList( 'WIKI' );
+$data = $quandl->getList( 'WIKI', 1, 10 );
 ```
 
 Returns a list of symbols in a given source. Number of results per page is 
@@ -268,7 +268,7 @@ limited to 300 by default.
 mixed getMeta( string $source )
 
 // Example
-$data = $quandl->getMeta( 'WIKI' )
+$data = $quandl->getMeta( 'WIKI' );
 ```
 
 Returns metadata about a symbol.
@@ -280,8 +280,8 @@ Returns metadata about a symbol.
 mixed getDatabases( [int $page, int $per_page] )
 
 // Examples
-$data = $quandl->getDatabases()
-$data = $quandl->getDatabases( 1, 10 )
+$data = $quandl->getDatabases();
+$data = $quandl->getDatabases( 1, 10 );
 ```
 
 Returns a list of available databases. Number of results per page is 
@@ -296,8 +296,8 @@ limited to 100 by default.
 boolean getBulk( string $database, string $path [, boolean $complete] )
 
 // Examples
-boolean getBulk( 'EOD', 'eod-partial.zip' )
-boolean getBulk( 'EOD', 'eod-full.zip', true )
+boolean getBulk( 'EOD', 'eod-partial.zip' );
+boolean getBulk( 'EOD', 'eod-full.zip', true );
 ```
 
 Downloads the entire database and saves it to a ZIP file. If `$complete` 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ response came from the cache.
 
 ```php
 mixed get( string $path [, array $params ] )
+
+// Examples
+$data = $quandl->get( 'datasets/EOD/QQQ' );
+$data = $quandl->get( 'datasets/EOD/QQQ', ['rows' => 5] );
 ```
 
 Returns an object containing the response from any of Quandl's API
@@ -210,6 +214,10 @@ automatically appended.
 
 ```php
 mixed getSymbol( string $symbol [, array $params ] )
+
+// Examples
+$data = $quandl->getSymbol( 'WIKI/AAPL' )
+$data = $quandl->getSymbol( 'WIKI/AAPL', ['rows' => 5] )
 ```
 
 Returns an object containing data for a given symbol. The format
@@ -226,6 +234,10 @@ automatically appended.
 
 ```php
 mixed getSearch( string $query [, int $page, int $per_page] )
+
+// Examples
+$data = $quandl->getSearch( "gold" )
+$data = $quandl->getSearch( "gold", 1, 10 )
 ```
 
 Returns a search result object. Number of results per page is 
@@ -240,6 +252,10 @@ string instead.
 
 ```php
 mixed getList( string $source [, int $page, int $per_page] )
+
+// Examples
+$data = $quandl->getList( 'WIKI' )
+$data = $quandl->getList( 'WIKI', 1, 10 )
 ```
 
 Returns a list of symbols in a given source. Number of results per page is 
@@ -250,6 +266,9 @@ limited to 300 by default.
 
 ```php
 mixed getMeta( string $source )
+
+// Example
+$data = $quandl->getMeta( 'WIKI' )
 ```
 
 Returns metadata about a symbol.
@@ -259,10 +278,32 @@ Returns metadata about a symbol.
 
 ```php
 mixed getDatabases( [int $page, int $per_page] )
+
+// Examples
+$data = $quandl->getDatabases()
+$data = $quandl->getDatabases( 1, 10 )
 ```
 
 Returns a list of available databases. Number of results per page is 
 limited to 100 by default.
+
+
+#### `getBulk`
+
+> This feature is only supported with premium databases.
+
+```php
+boolean getBulk( string $database, string $path [, boolean $complete] )
+
+// Examples
+boolean getBulk( 'EOD', 'eod-partial.zip' )
+boolean getBulk( 'EOD', 'eod-full.zip', true )
+```
+
+Downloads the entire database and saves it to a ZIP file. If `$complete` 
+is true (false by default), it will download the entire database, otherwise,
+it will download the last day only.
+
 
 
 [1]: https://www.quandl.com/help/api

--- a/tests/QuandlTest.php
+++ b/tests/QuandlTest.php
@@ -30,8 +30,8 @@ class QuandlTest extends PHPUnit_Framework_TestCase {
 		$quandl = new Quandl($this->api_key);
 		$r = $quandl->get("datasets/GOOG/NASDAQ_AAPL", ['rows' => 5]);
 
-		$this->assertEquals('GOOG', $r->dataset->database_code, "TEST get database_code");
-		$this->assertEquals(5, count($r->dataset->data), "TEST get data count");
+		$this->assertEquals('GOOG', $r->dataset->database_code);
+		$this->assertEquals(5, count($r->dataset->data));
 	}
 
 	public function testCsv() {
@@ -65,33 +65,33 @@ class QuandlTest extends PHPUnit_Framework_TestCase {
 	public function testInvalidUrl() {
 		$quandl = new Quandl($this->api_key, "json");
 		$r = $quandl->getSymbol("INVALID/SYMBOL", $this->dates);
-		$this->assertEquals($quandl->error, "Invalid URL", "TEST invalidUrl response");
+		$this->assertEquals($quandl->error, "Invalid URL");
 	}
 
 	public function testGetList() {
 		$quandl = new Quandl($this->api_key);
 		$r = $quandl->getList("WIKI", 1, 10);
-		$this->assertEquals(10, count($r->datasets), "TEST getList count");
+		$this->assertEquals(10, count($r->datasets));
 	}
 
 	public function testGetSearch() {
 		$quandl = new Quandl($this->api_key);
 		$r = $quandl->getSearch("crud oil", 1, 10);
-		$this->assertEquals(10, count($r->datasets), "TEST getSearch count");
+		$this->assertEquals(10, count($r->datasets));
 	}
 
 	public function testGetMeta() {
 		$quandl = new Quandl($this->api_key);
 		$r = $quandl->getMeta("GOOG/NASDAQ_AAPL");
-		$this->assertEquals('NASDAQ_AAPL', $r->dataset->dataset_code, "TEST getMeta dataset_code");
-		$this->assertEquals('GOOG', $r->dataset->database_code, "TEST getMeta database_code");
+		$this->assertEquals('NASDAQ_AAPL', $r->dataset->dataset_code);
+		$this->assertEquals('GOOG', $r->dataset->database_code);
 	}
 
 	public function testGetDatabases() {
 		$quandl = new Quandl($this->api_key);
 		$r = $quandl->getDatabases(1, 5);
-		$this->assertEquals(5, count($r->databases), "TEST getDatabases count");
-		$this->assertTrue(array_key_exists('database_code', $r->databases[0]), "TEST getDatabases keys");
+		$this->assertEquals(5, count($r->databases));
+		$this->assertTrue(array_key_exists('database_code', $r->databases[0]));
 	}
 
 	public function testCache() {
@@ -99,15 +99,12 @@ class QuandlTest extends PHPUnit_Framework_TestCase {
 		$quandl->cache_handler = array($this, "cacheHandler");
 		$r = $quandl->getSymbol($this->symbol, $this->dates);
 		$count = count($r->dataset->data);
-		$this->assertFalse($quandl->was_cached, 
-			"TEST was_cache should be false");
+		$this->assertFalse($quandl->was_cached);
 
 		$r = $quandl->getSymbol($this->symbol, $this->dates);
-		$this->assertEquals($count, count($r->dataset->data), 
-			"TEST count before and after cache should match");
+		$this->assertEquals($count, count($r->dataset->data));
 
-		$this->assertTrue($quandl->was_cached, 
-			"TEST was_cache should be true");
+		$this->assertTrue($quandl->was_cached);
 	}
 
 	// ---
@@ -136,11 +133,11 @@ class QuandlTest extends PHPUnit_Framework_TestCase {
 			$quandl_format = "json";
 		}
 
-		$this->assertGreaterThan($length, strlen($r), "TEST $format length");
+		$this->assertGreaterThan($length, strlen($r), "Length is shorter ($format)");
 		
 		$this->assertEquals(
 			"https://www.quandl.com/api/v3/datasets/{$this->symbol}.{$quandl_format}?trim_start={$this->dates['trim_start']}&trim_end={$this->dates['trim_end']}&auth_token={$this->api_key}",
-			$quandl->last_url, "TEST $format url");
+			$quandl->last_url, "URL Mismatch ($format)");
 	}
 
 	private function _testBulk($force_curl=false) {

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,10 +1,12 @@
 PHP Quandl Unit Tests
-=====================
+==================================================
+
 
 This folder contains PHPUnit unit tests. You do not need it for 
 production and can safely delete it if you are not using PHPUnit.
 
-## Run Tests
+Run Tests
+--------------------------------------------------
 
     $ phpunit --stop-on-failure .
 
@@ -21,10 +23,24 @@ To test a specific method:
   $ phpunit --stop-on-failure --filter PartialMethodName .
 
 
-## Travis
+Testing Bulk Downloads with a Premium Database
+--------------------------------------------------
+
+The bulk download methods require a premium database, therefore, the tests
+for bulk downloads are skipped by default. 
+
+To enable them, set the environment variable `QUANDL_PREMIUM` to a premium
+database you are subscribed to, prior to running the tests. For example:
+
+    $ export QUANDL_KEY=your_key_here
+    $ export QUANDL_PREMIUM=EOD
+    $ phpunit --stop-on-failure .
+
+
+Travis
+--------------------------------------------------
 
 If many tests are run through Travis CI, they will eventually fail due to 
 Quandl key-less API quota. You can define the `QUANDL_KEY` environmnt 
 variable in the travis repo settings.
-
 


### PR DESCRIPTION
Quandl allows downloading the entire database, for premium databases.

This method is now also supported in PHP Quandl, with the `getBulk( $database, $path )` method.

Implementation notes:

- Should work properly with either simple download or curl (auto detected behind the scenes, like the regular download methods).
- This method does not use cache handler if provided, there seems to be little reason to do so.
- Tests for the new method are included as optional (skipped by default). They can be turned on by setting an environment variable (see the README in the tests folder for more info).

This PR comes to at least partially address #10 

