### PR TITLE
Wrong results on getList

### DIFF
--- a/Quandl.php
+++ b/Quandl.php
@@ -92,10 +92,10 @@ class Quandl {
 	// getList returns the list of symbols for a given source.
 	public function getList($source, $page=1, $per_page=300) {
 		$params = [
-			"query"       => "*",
-			"source_code" => $source, 
-			"per_page"    => $per_page, 
-			"page"        => $page, 
+			"query"         => "*",
+			"database_code" => $source, 
+			"per_page"      => $per_page, 
+			"page"          => $page, 
 		];
 		$url = $this->getUrl("list", $this->getFormat(), 
 			$this->arrangeParams($params));


### PR DESCRIPTION
I don't know if they changed the parameter but if I change `source_code` to `database_code` it's all working properly again.

Old url:
https://www.quandl.com/api/v3/datasets.json?source_code=WIKI&per_page=100&sort_by=id&page=1
New url:
https://www.quandl.com/api/v3/datasets.json?database_code=WIKI&per_page=100&sort_by=id&page=1