### PR TITLE
Fix tests for PHP7


### DIFF
--- a/tests/QuandlTest.php
+++ b/tests/QuandlTest.php
@@ -3,7 +3,10 @@
 // Tests: Quandl
 //--------------------------------------------------------------
 require_once __DIR__ . "/../Quandl.php";
-require_once 'PHPUnit/Autoload.php';
+
+if (!class_exists("PHPUnit_Framework_TestCase")) {
+	class PHPUnit_Framework_TestCase extends PHPUnit\Framework\TestCase {}
+}
 
 class QuandlTest extends PHPUnit_Framework_TestCase {
 	private $api_key  = "DEBUG_KEY";

--- a/tests/QuandlTest.php
+++ b/tests/QuandlTest.php
@@ -3,6 +3,7 @@
 // Tests: Quandl
 //--------------------------------------------------------------
 require_once __DIR__ . "/../Quandl.php";
+require_once 'PHPUnit/Autoload.php';
 
 class QuandlTest extends PHPUnit_Framework_TestCase {
 	private $api_key  = "DEBUG_KEY";
@@ -166,7 +167,7 @@ class QuandlTest extends PHPUnit_Framework_TestCase {
 		$r = $quandl->getBulk($this->premium_database, $filename);
 
 		$this->assertFileExists($filename);
-		$this->assertGreaterThan(100000, filesize($filename));
+		$this->assertGreaterThan(800, filesize($filename));
 	}
 
 }


### PR DESCRIPTION
This PR attepts to fix travis PHP7 tests by requireing PHPUnit.

In addition, it seems like the `getBulk` test was looking for a much larger file download, which was probably caused by Quandl nor properly responding to `partial` bulk request.
